### PR TITLE
Correctly process EADs missing namespaces

### DIFF
--- a/lib/solr_ead/behaviors.rb
+++ b/lib/solr_ead/behaviors.rb
@@ -9,7 +9,8 @@ module SolrEad::Behaviors
   # It'll make an attempt at substituting numbered component levels for non-numbered
   # ones.
   def components(file)
-    raw = File.read(file).gsub!(/xmlns="(.*?)"/, '')
+    raw = File.read(file)
+    raw.gsub!(/xmlns="(.*?)"/, '')
     raw.gsub!(/c[0-9]{2,2}/,"c")
     xml = Nokogiri::XML(raw)
     return xml.xpath("//c")

--- a/spec/fixtures/ead_messy_format.xml
+++ b/spec/fixtures/ead_messy_format.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ead xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd" xmlns:ns2="http://www.w3.org/1999/xlink" xmlns="urn:isbn:1-931666-22-9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">  <eadheader findaidstatus="Complete" repositoryencoding="iso15511" countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b">
+<!-- Legacy EADs could be missing namespace declarations -->
+<ead>  <eadheader findaidstatus="Complete" repositoryencoding="iso15511" countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b">
     <eadid>sample_ead2</eadid>
     <filedesc></filedesc>
     <profiledesc></profiledesc>


### PR DESCRIPTION
The return value of `gsub!` is nil if the pattern is not matched.  As a result, [`Behaviors#components`](https://github.com/awead/solr_ead/blob/master/lib/solr_ead/behaviors.rb#L13) can fail if it is given an EAD without namespace declarations.  I've tweaked `ead_messy_format.xml` to add this problem, since I still run into this issue with legacy EADs.  Fix included.