### PR TITLE
Address build failures from nokogiri/activesupport/Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 rvm:
   - 2.0
   - 2.1
+  - 2.2
+  - 2.2.7
+  - 2.3.3
+  - 2.4.0
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/solr_ead.gemspec
+++ b/solr_ead.gemspec
@@ -29,4 +29,12 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'rdoc'
   gem.add_development_dependency 'jettywrapper'
+
+  gem.add_dependency 'activesupport', '< 5' if RUBY_VERSION < '2.2.2'
+
+  if RUBY_VERSION < '2.1'
+    gem.add_dependency 'nokogiri', '< 1.7'
+    gem.add_dependency 'deprecation', '< 1'
+  end
+
 end


### PR DESCRIPTION
* Constrain activesupport and nokogiri versions depending on Ruby version
* Add more recent Ruby versions to build matrix