### PR TITLE
replace deprecated constants TRUE/FALSE

### DIFF
--- a/lib/solr_ead/behaviors.rb
+++ b/lib/solr_ead/behaviors.rb
@@ -118,7 +118,7 @@ module SolrEad::Behaviors
   # Returns true or false for a component with attached <c> child nodes.
   def component_children?(node, t = Array.new)
     node.children.each { |n| t << n.name }
-    t.include?("c") ? TRUE : FALSE
+    t.include?("c")
   end
 
 end


### PR DESCRIPTION
This PR fixes deprecation warnings:

```
solr_ead/lib/solr_ead/behaviors.rb:123: warning: constant ::TRUE is deprecated
solr_ead/lib/solr_ead/behaviors.rb:123: warning: constant ::FALSE is deprecated
```