### PR TITLE
[WorkInProgress]: component indexing performance and accuracy improvements

### DIFF
--- a/lib/solr_ead/component.rb
+++ b/lib/solr_ead/component.rb
@@ -71,7 +71,7 @@ class SolrEad::Component
 
   def to_solr(solr_doc = Hash.new)
     super(solr_doc)
-    Solrizer.insert_field(solr_doc, "ref", self.ref.first.strip, :stored_sortable)
+    Solrizer.insert_field(solr_doc, "ref", self.ref.first.strip, :stored_sortable) if self.ref
   end
 
 end


### PR DESCRIPTION
This PR:

* changes the implementation for `components` to use Nokogiri functions to strip namespaces and rename components to the `c` element (this is a more targeted approach the than gsubs)

* saves a Nokogiri document creation call in `prep` and does a more efficient deep copy. This helps speed up the indexing of documents with many many components and large-ish terminologies. 

* changes the implementation for `component_children?` to return on the first child discovered

* fixes a bug when `ref` is missing

Tested with ~5,000 components. Some profiling shows that a lot of time (~30%) is spend creating these component-level documents (e.g., `new` and `to_xml` calls) so the `prep` function is a key function to focus on for performance tuning.

```
  %   cumulative   self              self     total
 time   seconds   seconds    calls  ms/call  ms/call  name
 25.10   268.66    268.66    14775    18.18    20.83  Nokogiri::XML::Document.read_memory
  4.10   312.54     43.88    39366     1.11     1.22  Nokogiri::XML::Node#native_write_to
  4.06   355.99     43.45   234842     0.19     0.19  Nokogiri::XML::XPathContext#evaluate
  3.98   398.59     42.60   641934     0.07     0.28  OM::XML::TermXpathGenerator.generate_xpath_with_indexes
  3.65   437.68     39.09 13274681     0.00     0.00  Exception#initialize
  2.73   466.88     29.20   704337     0.04     0.08  Nokogiri::XML::Searchable#extract_params
  2.66   495.34     28.46  1379001     0.02     0.05  OM.destringify
  2.60   523.15     27.81   836475     0.03     0.06  OM::XML::Terminology#retrieve_term
  2.22   546.96     23.81  2671578     0.01     0.97  Array#each
  2.02   568.56     21.60   635213     0.03     0.25  Solrizer::Suffix#to_s
  1.85   588.35     19.79   166829     0.12     1.43  OM::XML::TermValueOperators#term_values
  1.61   605.62     17.27   469684     0.04     0.40  Nokogiri::XML::Searchable#xpath
  1.50   621.64     16.02   397574     0.04     0.08  OpenStruct#new_ostruct_member!
  1.29   635.44     13.80  1610379     0.01     0.01  Kernel#initialize_dup
  1.23   648.60     13.16  1519459     0.01     0.02  Kernel#dup
  1.05   659.85     11.25   397587     0.03     0.11  OpenStruct#method_missing
  0.88   669.27      9.42   270540     0.03     0.23  Sanitize::Config.merge
```