### PR TITLE
validate that we have a good 'ref' before we use it in to_solr	

### DIFF
--- a/lib/solr_ead/component.rb
+++ b/lib/solr_ead/component.rb
@@ -71,7 +71,8 @@ class SolrEad::Component
 
   def to_solr(solr_doc = Hash.new)
     super(solr_doc)
-    Solrizer.insert_field(solr_doc, "ref", self.ref.first.strip, :stored_sortable)
+    Solrizer.insert_field(solr_doc, "ref", self.ref.first.strip, :stored_sortable) unless self.ref.blank? || self.ref.first.blank?
+    solr_doc
   end
 
 end

--- a/spec/component_spec.rb
+++ b/spec/component_spec.rb
@@ -3,17 +3,18 @@ require "spec_helper"
 describe SolrEad::Component do
 
   context "with parent components" do
+    let(:xml_data) { fixture "component_template.xml" }
+    let(:additional_fields) { {
+            "id"                                                        => "TEST-0001ref010",
+            Solrizer.solr_name("ead", :stored_sortable)                 => "TEST-0001",
+            Solrizer.solr_name("parent", :stored_sortable)              => "ref001",
+            Solrizer.solr_name("parent", :displayable)                  => ["ref001", "ref002", "ref003"],
+            Solrizer.solr_name("parent_unittitles", :displayable)       => ["Series I", "Subseries A", "Subseries 1"],
+            Solrizer.solr_name("component_children", :type => :boolean) => false
+    } }
 
     let(:subject) do
-      additional_fields = {
-        "id"                                                        => "TEST-0001ref010",
-        Solrizer.solr_name("ead", :stored_sortable)                 => "TEST-0001",
-        Solrizer.solr_name("parent", :stored_sortable)              => "ref001",
-        Solrizer.solr_name("parent", :displayable)                  => ["ref001", "ref002", "ref003"],
-        Solrizer.solr_name("parent_unittitles", :displayable)       => ["Series I", "Subseries A", "Subseries 1"],
-        Solrizer.solr_name("component_children", :type => :boolean) => FALSE
-      }
-      SolrEad::Component.from_xml(fixture "component_template.xml").to_solr(additional_fields)
+      SolrEad::Component.from_xml(xml_data).to_solr(additional_fields)
     end
 
     it "should accept additional fields from a hash" do
@@ -24,6 +25,21 @@ describe SolrEad::Component do
 
     it "should create fields using type" do
       expect(subject[Solrizer.solr_name("ref", :stored_sortable)]).to eq("ref215")
+    end
+
+    context '#refs' do
+      context 'missing ones' do
+        let(:xml_data) { fixture("component_template.xml").read.gsub(/id=".*"\s/, '') }
+        it do
+          expect(subject[Solrizer.solr_name("ref", :stored_sortable)]).to be_nil
+        end
+      end
+      context 'blank ones' do
+        let(:xml_data) { fixture("component_template.xml").read.gsub(/id=".*"\s/, 'id=" "') }
+        it do
+          expect(subject[Solrizer.solr_name("ref", :stored_sortable)]).to be_nil
+        end
+      end
     end
 
   end
@@ -37,7 +53,7 @@ describe SolrEad::Component do
         Solrizer.solr_name("parent", :stored_sortable)              => "ref001",
         Solrizer.solr_name("parent", :displayable)                  => ["ref001", "ref002", "ref003"],
         Solrizer.solr_name("parent_unittitles", :displayable)       => [],
-        Solrizer.solr_name("component_children", :type => :boolean) => FALSE
+        Solrizer.solr_name("component_children", :type => :boolean) => false
       }
       SolrEad::Component.from_xml(fixture "component_template.xml").to_solr(additional_fields)
     end
@@ -47,7 +63,7 @@ describe SolrEad::Component do
       expect(subject[Solrizer.solr_name("accessrestrict", :displayable)].first).to match /^This item .* is available.$/
     end
 
-  end    
+  end
 
   describe "formatting fields as html" do
     let(:subject) { SolrEad::Component.from_xml(fixture "html_component.xml") }


### PR DESCRIPTION
This PR fixes an exception when `ref` is missing.