### PR TITLE
use nokogiri functions to load components XML

### DIFF
--- a/lib/solr_ead/behaviors.rb
+++ b/lib/solr_ead/behaviors.rb
@@ -6,14 +6,18 @@ module SolrEad::Behaviors
 
   # Takes a file as its input and returns a Nokogiri::XML::NodeSet of component <c> nodes
   #
-  # It'll make an attempt at substituting numbered component levels for non-numbered
+  # It'll make an attempt at substituting numbered component levels (c01..c12) for non-numbered
   # ones.
+  # @param [String] `file` pathname to file with EAD data
   def components(file)
-    raw = File.read(file)
-    raw.gsub!(/xmlns="(.*?)"/, '')
-    raw.gsub!(/c[0-9]{2,2}/,"c")
-    xml = Nokogiri::XML(raw)
-    return xml.xpath("//c")
+    doc = Nokogiri::XML(File.read(file))
+    doc.remove_namespaces!
+    (1..12).each do |i| # EAD spec provides 12 levels of components
+      doc.xpath("//c#{'%02d' % i}").each do |node|
+        node.name = 'c'
+      end
+    end
+    doc.xpath('//c')
   end
 
   # Used in conjunction with #components, this takes a single Nokogiri::XML::Element


### PR DESCRIPTION
This PR changes the implementation for `components` to use Nokogiri functions to strip namespaces and rename components to the `c` element (this is a more targeted approach the than gsubs)

