### PR TITLE
return true on first component in children

### DIFF
--- a/lib/solr_ead/behaviors.rb
+++ b/lib/solr_ead/behaviors.rb
@@ -121,10 +121,10 @@ module SolrEad::Behaviors
     end
   end
 
-  # Returns true or false for a component with attached <c> child nodes.
-  def component_children?(node, t = Array.new)
-    node.children.each { |n| t << n.name }
-    t.include?("c")
+  # @param [Nokogiri::XML::Node] `node`
+  # @return true or false for a component with attached <c> child nodes.
+  def component_children?(node)
+    node.children.any? { |n| n.name == 'c' }
   end
 
 end


### PR DESCRIPTION
This PR changes the implementation for `component_children?` to return on the first child discovered. It improves performance when the number of children is large.


