### PR TITLE
cache values from Solrizer.solr_name

### DIFF
--- a/lib/solr_ead/behaviors.rb
+++ b/lib/solr_ead/behaviors.rb
@@ -68,18 +68,27 @@ module SolrEad::Behaviors
   # within the hierarchy of the original ead.
   def additional_component_fields(node, addl_fields = Hash.new)
     addl_fields["id"]                                                        = [node.xpath("//eadid").text, node.attr("id")].join
-    addl_fields[Solrizer.solr_name("ead", :stored_sortable)]                 = node.xpath("//eadid").text
-    addl_fields[Solrizer.solr_name("parent", :stored_sortable)]              = node.parent.attr("id") unless node.parent.attr("id").nil?
-    addl_fields[Solrizer.solr_name("parent", :displayable)]                  = parent_id_list(node)
-    addl_fields[Solrizer.solr_name("parent_unittitles", :displayable)]       = parent_unittitle_list(node)
-    addl_fields[Solrizer.solr_name("parent_unittitles", :searchable)]        = parent_unittitle_list(node)
-    addl_fields[Solrizer.solr_name("component_level", :type => :integer)]    = parent_id_list(node).length + 1
-    addl_fields[Solrizer.solr_name("component_children", :type => :boolean)] = component_children?(node)
-    addl_fields[Solrizer.solr_name("collection", :facetable)]                = node.xpath("//archdesc/did/unittitle").text
-    addl_fields[Solrizer.solr_name("collection", :displayable)]              = node.xpath("//archdesc/did/unittitle").text
-    addl_fields[Solrizer.solr_name("repository", :facetable)]                = node.xpath("//archdesc/did/repository").text.strip
-    addl_fields[Solrizer.solr_name("repository", :displayable)]              = node.xpath("//archdesc/did/repository").text.strip
+    addl_fields[to_solr_name("ead", :stored_sortable)]                 = node.xpath("//eadid").text
+    addl_fields[to_solr_name("parent", :stored_sortable)]              = node.parent.attr("id") unless node.parent.attr("id").nil?
+    addl_fields[to_solr_name("parent", :displayable)]                  = parent_id_list(node)
+    addl_fields[to_solr_name("parent_unittitles", :displayable)]       = parent_unittitle_list(node)
+    addl_fields[to_solr_name("parent_unittitles", :searchable)]        = parent_unittitle_list(node)
+    addl_fields[to_solr_name("component_level", :type => :integer)]    = parent_id_list(node).length + 1
+    addl_fields[to_solr_name("component_children", :type => :boolean)] = component_children?(node)
+    addl_fields[to_solr_name("collection", :facetable)]                = node.xpath("//archdesc/did/unittitle").text
+    addl_fields[to_solr_name("collection", :displayable)]              = node.xpath("//archdesc/did/unittitle").text
+    addl_fields[to_solr_name("repository", :facetable)]                = node.xpath("//archdesc/did/repository").text.strip
+    addl_fields[to_solr_name("repository", :displayable)]              = node.xpath("//archdesc/did/repository").text.strip
     return addl_fields
+  end
+
+  # @param `args` same as `Solrizer.solr_name`
+  # @return [String] value from `Solrizer.solr_name` but caches results
+  def to_solr_name(*args)
+    @solr_name_cache = {} unless @solr_name_cache
+    cache_key = [*args].to_s
+    return @solr_name_cache[cache_key] if @solr_name_cache[cache_key]
+    @solr_name_cache[cache_key] = Solrizer.solr_name(*args)
   end
 
   # Array of all id attributes from the component's parent <c> nodes, sorted in descending order

--- a/spec/behaviors_spec.rb
+++ b/spec/behaviors_spec.rb
@@ -21,17 +21,29 @@ describe SolrEad::Behaviors do
       expect(non_numbered_nodeset.count).to eq(135)
       expect(numbered_nodeset.count).to eq(83)
     end
-    
+
     it "should find some components even if ead is messily formatted" do
       expect(messy_nodeset.count).to be > 0
     end
-    
+
   end
 
   describe "#prep" do
     let(:subject) { TestClass.new.prep(fixture("pp002010.xml")) }
     it "should return a single component document" do
       expect(subject).to be_a_kind_of(Nokogiri::XML::Document)
+    end
+  end
+
+  describe '#to_solr_name' do
+    subject(:test_obj) { TestClass.new }
+    it 'caches the value of Solrizer.solr_name' do
+      expect(Solrizer).to receive(:solr_name).and_call_original
+      expect(test_obj.to_solr_name('my_test', :facetable)).to eq 'my_test_sim'
+
+      # second time should be cached
+      expect(Solrizer).not_to receive(:solr_name)
+      expect(test_obj.to_solr_name('my_test', :facetable)).to eq 'my_test_sim'
     end
   end
 


### PR DESCRIPTION
This PR improves performance by caching the `Solrizer.solr_name` calls that do not change but happen in deep loops.