### PR TITLE
Speed up #additional_component_fields

### DIFF
--- a/lib/solr_ead/version.rb
+++ b/lib/solr_ead/version.rb
@@ -1,3 +1,3 @@
 module SolrEad
-  VERSION = "0.7.4"
+  VERSION = "0.7.5"
 end


### PR DESCRIPTION
`#additional_component_fields` is a bottleneck, mostly due to the parent unittitle generation (see my next pull request). However, there's some basic cleanup that increases the speed by about 50%.

(Sorry about the version number. My git-foo isn't good enough to take it out of this commit, and since it's a no-op I didn't spend a lot of time trying to figure it out.)