### PR TITLE
Fix build to allow for merging of #20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.2.7


### PR DESCRIPTION
This incorporates the commit from @billdueber's pull request #20 and removes Ruby 2.0 from the build matrix (which is far into its EOL period).

With these changes I'm expecting that we probably want to ship the next release of solr_ead as 0.8.0.