### PR TITLE
add require rake to lib/solr_ead.rb

### DIFF
--- a/lib/solr_ead.rb
+++ b/lib/solr_ead.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'solrizer'
 require 'om'
+require 'rake'
 require 'rsolr'
 require 'active_support'
 require 'yaml'


### PR DESCRIPTION
Ran into an `undefined method 'namespace'` error caused by solr_ead when trying to build Arclight. Resolved by adding `require 'rake'` to lib/solr_ead.rb